### PR TITLE
fix(ci): restore main's ability to build under typescript 6.0.3

### DIFF
--- a/packages/github-actions-grafana-jump/package.json
+++ b/packages/github-actions-grafana-jump/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@types/greasemonkey": "~4.0.7",
-    "typescript": "~5.8.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/packages/github-actions-grafana-jump/tsconfig.json
+++ b/packages/github-actions-grafana-jump/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // This is the only package that references ambient globals from
+    // @types/node (the `module` test-export guard) and @types/greasemonkey
+    // (`GM`). Under moduleResolution: bundler, tsc does not auto-include
+    // these from node_modules/@types the way it does under "node"/"node10" -
+    // list them explicitly rather than relying on that auto-discovery.
+    "types": ["node", "greasemonkey"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/graphite-to-github-button/src/index.ts
+++ b/packages/graphite-to-github-button/src/index.ts
@@ -1,0 +1,67 @@
+// ==UserScript==
+// @name        Graphite => GitHub button
+// @description Add a button to go from app.graphite.dev to github.com
+// @match       https://app.graphite.dev/*
+// @version      0.3.3
+// @run-at      document-start
+// @icon         data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
+// @grant        none
+// @license      MIT
+// @namespace https://app.graphite.dev
+// @downloadURL https://update.greasyfork.org/scripts/509841/Graphite%20%3D%3E%20GitHub%20button.user.js
+// @updateURL https://update.greasyfork.org/scripts/509841/Graphite%20%3D%3E%20GitHub%20button.meta.js
+// ==/UserScript==
+
+const PATH_REGEX = /^\/github\/pr\/([^\/]+)\/([^\/]+)\/([^\/]+).*$/;
+const SELECTOR =
+  '[class^="PullRequestTitleBar_container_"] > div:nth-child(1) > div:nth-child(2)';
+
+const addButton = (toolbar: HTMLElement) => {
+  const match = window.location.pathname.match(PATH_REGEX);
+  if (!match) return;
+  
+  const [_, org, repo, pr] = match;
+  const gitHubLink = `https://github.com/${org}/${repo}/pull/${pr}`;
+
+  if (document.getElementById("gitHubLink") != null) {
+    return;
+  }
+
+  const anchorEl = document.createElement("a");
+  anchorEl.setAttribute("id", "gitHubLink");
+  anchorEl.setAttribute("href", gitHubLink);
+  anchorEl.setAttribute("target", "_blank");
+  anchorEl.setAttribute(
+    "style",
+    "background: #f0f0f333; padding: 6px; border-radius: 4px; flex-shrink: 0;"
+  );
+  anchorEl.appendChild(document.createTextNode("GitHub ↗️"));
+
+  toolbar.appendChild(anchorEl);
+};
+
+const toolbarObserver = new MutationObserver((_, observer) => {
+  const toolbar = document.querySelector(SELECTOR) as HTMLElement;
+  if (toolbar) {
+    observer.disconnect();
+    addButton(toolbar);
+  }
+});
+
+let lastPathname: string | undefined;
+const routeChangeObserver = new MutationObserver(() => {
+  const { pathname } = window.location;
+
+  if (pathname !== lastPathname) {
+    lastPathname = pathname;
+
+    if (pathname.match(PATH_REGEX)) {
+      toolbarObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+});
+
+routeChangeObserver.observe(document.body, { childList: true, subtree: true });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,11 @@
     "target": "ES2020",
     "module": "ESNext",
     "lib": ["ES2020", "DOM"],
-    "moduleResolution": "node",
+    // "node" (an alias for the legacy "node10" strategy) is deprecated as of
+    // TypeScript 6.0 and will stop functioning in 7.0 (TS5107). "bundler" is
+    // the modern pairing for `module: ESNext`; no package in this repo does
+    // external module imports, so this has no effect on compiled output.
+    "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,7 +410,7 @@ __metadata:
   resolution: "@nsheaps/gm-github-actions-grafana-jump@workspace:packages/github-actions-grafana-jump"
   dependencies:
     "@types/greasemonkey": "npm:~4.0.7"
-    typescript: "npm:~5.8.3"
+    typescript: "npm:~6.0.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

`main`'s CI has failed on **every push since 2026-07-21** (~10 commits, including the just-merged ADX-525 Grafana jump buttons feature, #4). Three independent, compounding causes, all fixed here:

- **`tsconfig.base.json`**: `moduleResolution: "node"` (deprecated alias for `node10`) is a hard error under TypeScript 6.0.3 (`TS5107`, removed entirely in 7.0). Switched to `"bundler"`, the modern pairing for `module: ESNext` — no package in this repo does external imports, so this has zero effect on compiled output.
- **`packages/github-actions-grafana-jump/tsconfig.json`**: under `moduleResolution: bundler`, `tsc` no longer auto-includes ambient globals from `node_modules/@types` the way it did under `"node"`. This package's `typeof module` test-export guard and `GM.*` API calls need an explicit `"types": ["node", "greasemonkey"]` to keep resolving.
- **`packages/github-actions-grafana-jump/package.json`**: still declared `"typescript": "~5.8.3"` — a stale copy from before the org-wide v6 bump, since this package was only added later via the ADX-525 PR and never got Renovate's bump. That mismatch against every other package's `~6.0.3` left `yarn.lock` without a consistent resolution, so `yarn install --immutable` (what CI actually runs) failed outright on some runs before ever reaching a TypeScript compile. Bumped to match; `yarn.lock` regenerated accordingly.

Also cherry-picked `4a38bf0` (from the still-open PR #7) to restore `packages/graphite-to-github-button/src/index.ts`, which has been missing from `main` since `4fc2806` renamed it straight to `dist/script.user.js` without ever compiling it — `tsc --build` for that package has been failing with "No inputs were found" independent of the typescript v6 issue, since before the v6 bump even landed.

## Test plan

- [x] `yarn install --immutable` succeeds (this is what CI runs, and was failing before this change)
- [x] `nx run-many --target=build --all --skip-nx-cache` succeeds for all 5 packages, cache bypassed
- [x] `github-actions-grafana-jump`'s existing 14 unit tests pass
- [x] Confirmed `packages/graphite-to-github-button/dist/script.user.js` (the already-committed, force-added artifact) is untouched by this change — bringing it back in sync with the now-restored `src/index.ts` is left to PR #7, which already does that plus its own separate regen-dist workflow generalization
- [ ] CI green on this PR (will confirm once checks run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)